### PR TITLE
Backport generic functionality from directxman12/k8s-prometheus adapter

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 807f261d8170be02e0c3802e4d005c334a04419a8b2e5f75d68498385202f5ff
-updated: 2017-06-07T14:38:39.211756323-04:00
+hash: 8ef6bf322e35b7e8a8fe2d27c78eea5bd4e653f9e4965a4595fda63f209edee3
+updated: 2017-07-06T15:29:56.092753806-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -192,6 +192,11 @@ imports:
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -491,4 +496,8 @@ imports:
   - pkg/apis/custom_metrics
   - pkg/apis/custom_metrics/install
   - pkg/apis/custom_metrics/v1alpha1
-testImports: []
+testImports:
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,3 +43,8 @@ import:
   subpackages:
   - pkg/apis/custom_metrics
   - pkg/apis/custom_metrics/install
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require

--- a/pkg/dynamicmapper/fake_discovery.go
+++ b/pkg/dynamicmapper/fake_discovery.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicmapper
+
+import (
+	"fmt"
+
+	"github.com/emicklei/go-restful-swagger12"
+
+	"github.com/go-openapi/spec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/pkg/api/v1"
+	kubeversion "k8s.io/client-go/pkg/version"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
+)
+
+// NB: this is a copy of k8s.io/client-go/discovery/fake.  The original returns `nil, nil`
+// for some methods, which is generally confuses lots of code.
+
+type FakeDiscovery struct {
+	*testing.Fake
+}
+
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	action := testing.ActionImpl{
+		Verb:     "get",
+		Resource: schema.GroupVersionResource{Resource: "resource"},
+	}
+	c.Invokes(action, nil)
+	for _, resourceList := range c.Resources {
+		if resourceList.GroupVersion == groupVersion {
+			return resourceList, nil
+		}
+	}
+	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
+}
+
+func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	action := testing.ActionImpl{
+		Verb:     "get",
+		Resource: schema.GroupVersionResource{Resource: "resource"},
+	}
+	c.Invokes(action, nil)
+	return c.Resources, nil
+}
+
+func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	groups := map[string]*metav1.APIGroup{}
+	groupVersions := map[metav1.GroupVersionForDiscovery]struct{}{}
+	for _, resourceList := range c.Resources {
+		groupVer, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		groupVerForDisc := metav1.GroupVersionForDiscovery{
+			GroupVersion: resourceList.GroupVersion,
+			Version:      groupVer.Version,
+		}
+
+		group, groupPresent := groups[groupVer.Group]
+		if !groupPresent {
+			group = &metav1.APIGroup{
+				Name: groupVer.Group,
+				// use the fist seen version as the preferred version
+				PreferredVersion: groupVerForDisc,
+			}
+			groups[groupVer.Group] = group
+		}
+
+		// we'll dedup in the end by deleting the group-versions
+		// from the global map one at a time
+		group.Versions = append(group.Versions, groupVerForDisc)
+		groupVersions[groupVerForDisc] = struct{}{}
+	}
+
+	groupList := make([]metav1.APIGroup, 0, len(groups))
+	for _, group := range groups {
+		newGroup := metav1.APIGroup{
+			Name:             group.Name,
+			PreferredVersion: group.PreferredVersion,
+		}
+
+		for _, groupVer := range group.Versions {
+			if _, ok := groupVersions[groupVer]; ok {
+				delete(groupVersions, groupVer)
+				newGroup.Versions = append(newGroup.Versions, groupVer)
+			}
+		}
+
+		groupList = append(groupList, newGroup)
+	}
+
+	return &metav1.APIGroupList{
+		Groups: groupList,
+	}, nil
+}
+
+func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+	action := testing.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = schema.GroupVersionResource{Resource: "version"}
+
+	c.Invokes(action, nil)
+	versionInfo := kubeversion.Get()
+	return &versionInfo, nil
+}
+
+func (c *FakeDiscovery) SwaggerSchema(version schema.GroupVersion) (*swagger.ApiDeclaration, error) {
+	action := testing.ActionImpl{}
+	action.Verb = "get"
+	if version == v1.SchemeGroupVersion {
+		action.Resource = schema.GroupVersionResource{Resource: "/swaggerapi/api/" + version.Version}
+	} else {
+		action.Resource = schema.GroupVersionResource{Resource: "/swaggerapi/apis/" + version.Group + "/" + version.Version}
+	}
+
+	c.Invokes(action, nil)
+	return &swagger.ApiDeclaration{}, nil
+}
+
+func (c *FakeDiscovery) OpenAPISchema() (*spec.Swagger, error) { return &spec.Swagger{}, nil }
+
+func (c *FakeDiscovery) RESTClient() restclient.Interface {
+	return nil
+}

--- a/pkg/dynamicmapper/mapper.go
+++ b/pkg/dynamicmapper/mapper.go
@@ -1,0 +1,114 @@
+package dynamicmapper
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+)
+
+// RengeneratingDiscoveryRESTMapper is a RESTMapper which Regenerates its cache of mappings periodically.
+// It functions by recreating a normal discovery RESTMapper at the specified interval.
+// We don't refresh automatically on cache misses, since we get called on every label, plenty of which will
+// be unrelated to Kubernetes resources.
+type RegeneratingDiscoveryRESTMapper struct {
+	discoveryClient   discovery.DiscoveryInterface
+	versionInterfaces meta.VersionInterfacesFunc
+
+	refreshInterval time.Duration
+
+	mu sync.RWMutex
+
+	delegate meta.RESTMapper
+}
+
+func NewRESTMapper(discoveryClient discovery.DiscoveryInterface, versionInterfaces meta.VersionInterfacesFunc, refreshInterval time.Duration) (*RegeneratingDiscoveryRESTMapper, error) {
+	mapper := &RegeneratingDiscoveryRESTMapper{
+		discoveryClient:   discoveryClient,
+		versionInterfaces: versionInterfaces,
+		refreshInterval:   refreshInterval,
+	}
+	if err := mapper.RegenerateMappings(); err != nil {
+		return nil, fmt.Errorf("unable to populate initial set of REST mappings: %v", err)
+	}
+
+	return mapper, nil
+}
+
+// RunUtil runs the mapping refresher until the given stop channel is closed.
+func (m *RegeneratingDiscoveryRESTMapper) RunUntil(stop <-chan struct{}) {
+	go wait.Until(func() {
+		if err := m.RegenerateMappings(); err != nil {
+			glog.Errorf("error regenerating REST mappings from discovery: %v", err)
+		}
+	}, m.refreshInterval, stop)
+}
+
+func (m *RegeneratingDiscoveryRESTMapper) RegenerateMappings() error {
+	resources, err := discovery.GetAPIGroupResources(m.discoveryClient)
+	if err != nil {
+		return err
+	}
+	newDelegate := discovery.NewRESTMapper(resources, m.versionInterfaces)
+
+	// don't lock until we're ready to replace
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.delegate = newDelegate
+
+	return nil
+}
+
+func (m *RegeneratingDiscoveryRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.KindFor(resource)
+}
+
+func (m *RegeneratingDiscoveryRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.KindsFor(resource)
+
+}
+func (m *RegeneratingDiscoveryRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.ResourceFor(input)
+
+}
+func (m *RegeneratingDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.ResourcesFor(input)
+
+}
+func (m *RegeneratingDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.RESTMapping(gk, versions...)
+
+}
+func (m *RegeneratingDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.RESTMappings(gk, versions...)
+}
+func (m *RegeneratingDiscoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.delegate.ResourceSingularizer(resource)
+}

--- a/pkg/dynamicmapper/mapper_test.go
+++ b/pkg/dynamicmapper/mapper_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicmapper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/pkg/api"
+	core "k8s.io/client-go/testing"
+)
+
+const testingMapperRefreshInterval = 1 * time.Second
+
+func setupMapper(t *testing.T, stopChan <-chan struct{}) (*RegeneratingDiscoveryRESTMapper, *FakeDiscovery) {
+	fakeDiscovery := &FakeDiscovery{Fake: &core.Fake{}}
+	mapper, err := NewRESTMapper(fakeDiscovery, api.Registry.InterfacesFor, testingMapperRefreshInterval)
+	require.NoError(t, err, "constructing the rest mapper shouldn't have produced an error")
+
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+			},
+		},
+	}
+
+	if stopChan != nil {
+		mapper.RunUntil(stopChan)
+	}
+
+	return mapper, fakeDiscovery
+}
+
+func TestRegeneratingUpdatesMapper(t *testing.T) {
+	mapper, fakeDiscovery := setupMapper(t, nil)
+	require.NoError(t, mapper.RegenerateMappings(), "regenerating the mappings the first time should not have yielded an error")
+
+	// add first, to ensure we don't update before regen
+	fakeDiscovery.Resources[0].APIResources = append(fakeDiscovery.Resources[0].APIResources, metav1.APIResource{
+		Name: "services", Namespaced: true, Kind: "Service",
+	})
+	fakeDiscovery.Resources = append(fakeDiscovery.Resources, &metav1.APIResourceList{
+		GroupVersion: "wardle/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{Name: "flunders", Namespaced: true, Kind: "Flunder"},
+		},
+	})
+
+	// fetch before regen
+	podsGVK, err := mapper.KindFor(schema.GroupVersionResource{Resource: "pods"})
+	require.NoError(t, err, "should have been able to fetch the kind for 'pods' the first time")
+	assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, podsGVK, "should have correctly fetched the kind for 'pods' the first time")
+	_, err = mapper.KindFor(schema.GroupVersionResource{Resource: "services"})
+	assert.Error(t, err, "should not have been able to fetch the kind for 'services' the first time")
+	_, err = mapper.KindFor(schema.GroupVersionResource{Resource: "flunders", Group: "wardle"})
+	assert.Error(t, err, "should not have been able to fetch the kind for 'flunders.wardle' the first time")
+
+	// regen and check again
+	require.NoError(t, mapper.RegenerateMappings(), "regenerating the mappings the second time should not have yielded an error")
+
+	podsGVK, err = mapper.KindFor(schema.GroupVersionResource{Resource: "pods"})
+	if assert.NoError(t, err, "should have been able to fetch the kind for 'pods' the second time") {
+		assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, podsGVK, "should have correctly fetched the kind for 'pods' the first time")
+	}
+	servicesGVK, err := mapper.KindFor(schema.GroupVersionResource{Resource: "services"})
+	if assert.NoError(t, err, "should have been able to fetch the kind for 'services' the second time") {
+		assert.Equal(t, schema.GroupVersionKind{Version: "v1", Kind: "Service"}, servicesGVK, "should have correctly fetched the kind for 'services' the second time")
+	}
+	flundersGVK, err := mapper.KindFor(schema.GroupVersionResource{Resource: "flunders", Group: "wardle"})
+	if assert.NoError(t, err, "should have been able to fetch the kind for 'flunders.wardle' the second time") {
+		assert.Equal(t, schema.GroupVersionKind{Version: "v1alpha1", Kind: "Flunder", Group: "wardle"}, flundersGVK, "should have correctly fetched the kind for 'flunders.wardle' the second time")
+	}
+}

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"net/http"
+
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewMetricNotFoundError returns a StatusError indicating the given metric could not be found.
+// It is similar to NewNotFound, but more specialized
+func NewMetricNotFoundError(resource schema.GroupResource, metricName string) *apierr.StatusError {
+	return &apierr.StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    int32(http.StatusNotFound),
+		Reason:  metav1.StatusReasonNotFound,
+		Message: fmt.Sprintf("the server could not find the metric %s for %s", metricName, resource.String()),
+	}}
+}
+
+// NewMetricNotFoundForError returns a StatusError indicating the given metric could not be found for
+// the given named object. It is similar to NewNotFound, but more specialized
+func NewMetricNotFoundForError(resource schema.GroupResource, metricName string, resourceName string) *apierr.StatusError {
+	return &apierr.StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    int32(http.StatusNotFound),
+		Reason:  metav1.StatusReasonNotFound,
+		Message: fmt.Sprintf("the server could not find the metric %s for %s %s", metricName, resource.String(), resourceName),
+	}}
+}

--- a/pkg/provider/interfaces_test.go
+++ b/pkg/provider/interfaces_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/pkg/api"
+
+	// install in order to make the types available for lookup
+	_ "k8s.io/client-go/pkg/api/install"
+)
+
+func TestNormalizeMetricInfoProducesSingularForm(t *testing.T) {
+	pluralInfo := MetricInfo{
+		GroupResource: schema.GroupResource{Resource: "pods"},
+		Namespaced:    true,
+		Metric:        "cpu_usage",
+	}
+
+	_, singularRes, err := pluralInfo.Normalized(api.Registry.RESTMapper())
+	require.NoError(t, err, "should not have returned an error while normalizing the plural MetricInfo")
+	assert.Equal(t, "pod", singularRes, "should have produced a singular resource from the pural metric info")
+}
+
+func TestNormalizeMetricInfoDealsWithPluralization(t *testing.T) {
+	singularInfo := MetricInfo{
+		GroupResource: schema.GroupResource{Resource: "pod"},
+		Namespaced:    true,
+		Metric:        "cpu_usage",
+	}
+
+	pluralInfo := MetricInfo{
+		GroupResource: schema.GroupResource{Resource: "pods"},
+		Namespaced:    true,
+		Metric:        "cpu_usage",
+	}
+
+	singularNormalized, singularRes, err := singularInfo.Normalized(api.Registry.RESTMapper())
+	require.NoError(t, err, "should not have returned an error while normalizing the singular MetricInfo")
+	pluralNormalized, pluralSingularRes, err := pluralInfo.Normalized(api.Registry.RESTMapper())
+	require.NoError(t, err, "should not have returned an error while normalizing the plural MetricInfo")
+
+	assert.Equal(t, singularRes, pluralSingularRes, "the plural and singular MetricInfo should have the same singularized resource")
+	assert.Equal(t, singularNormalized, pluralNormalized, "the plural and singular MetricInfo should have the same normailzed form")
+}


### PR DESCRIPTION
This commit backports a bunch of generic functionality from https://github.com/directxman12/k8s-prometheus-adapter, including:

- An updating REST mapper
- a function to "normalize" metric info across slightly different resource names
- error constructors for missing metrics