### PR TITLE
Updates deps for Kubernetes 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: go
 go:
 - 1.8
 
-# blech, Travis downloads with capitals in DirectXMan12, which confuses go
-go_import_path: github.com/directxman12/custom-metrics-boilerplate
-
 addons:
   apt:
     sources:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8ef6bf322e35b7e8a8fe2d27c78eea5bd4e653f9e4965a4595fda63f209edee3
-updated: 2017-07-06T15:29:56.092753806-04:00
+hash: 24afcdb6cd49dde25b4e9f94fbf89a91757395a9f2dcd0715ac42323789531f6
+updated: 2017-09-25T15:25:12.380271918-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -8,7 +8,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
-  version: 20490caaf0dcd96bb4a95e40625559def8ef5b04
+  version: 0520cb9304cb2385f7e72b8bc02d6e4d3257158a
   subpackages:
   - alarm
   - auth
@@ -79,14 +79,9 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
-- name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
-  subpackages:
-  - digest
-  - reference
 - name: github.com/elazarl/go-bindata-assetfs
   version: 3dcc96556217539f50599357fb481ac0dc7439b9
 - name: github.com/emicklei/go-restful
@@ -96,17 +91,13 @@ imports:
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/evanphx/json-patch
-  version: ba18e35c5c1b36ef6334cad706eb681153d2d379
+  version: 944e07253867aacae43c04b2e6a239005443f33a
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/analysis
-  version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/loads
-  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38
 - name: github.com/go-openapi/spec
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
@@ -127,14 +118,20 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
+- name: github.com/google/btree
+  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
-  version: 68f4ded48ba9414dab2ae69b3f0d69971da73aa5
+  version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
   - OpenAPIv2
   - compiler
   - extensions
+- name: github.com/gregjones/httpcache
+  version: 787624de3eb7bd915c329cba748687a3b22666a6
+  subpackages:
+  - diskcache
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
   version: 2500245aa6110c562d17020fb31a2c133d737799
 - name: github.com/grpc-ecosystem/grpc-gateway
@@ -148,13 +145,15 @@ imports:
   subpackages:
   - simplelru
 - name: github.com/howeyc/gopass
-  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/json-iterator/go
+  version: 36b14963da70d11297d313183d7e6388c8510e1e
 - name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -165,12 +164,20 @@ imports:
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/mxk/go-flowrate
+  version: cca7078d478f8520f85629ad7c68962d31ed7682
+  subpackages:
+  - flowrate
+- name: github.com/NYTimes/gziphandler
+  version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/peterbourgon/diskv
+  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
@@ -178,12 +185,15 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
   subpackages:
   - expfmt
+  - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -192,23 +202,21 @@ imports:
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
-- name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
-  subpackages:
-  - assert
-  - require
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - bcrypt
   - blowfish
+  - nacl/secretbox
+  - poly1305
+  - salsa20/salsa
   - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
   - html
@@ -221,13 +229,15 @@ imports:
   - trace
   - websocket
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
   - cases
+  - internal
   - internal/tag
   - language
   - runes
@@ -237,16 +247,25 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  subpackages:
+  - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  version: d2e1b51f33ff8c5e4a15560ff049d200e83726c5
   subpackages:
   - codes
   - credentials
+  - grpclb/grpc_lb_v1
   - grpclog
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - stats
+  - status
+  - tap
   - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
@@ -254,8 +273,35 @@ imports:
   version: 20b71e5b60d756d3d2f80def009790325acc2b23
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/api
+  version: cadaf100c0a3dd6b254f320d6d651df079ec8e0a
+  subpackages:
+  - admissionregistration/v1alpha1
+  - apps/v1beta1
+  - apps/v1beta2
+  - authentication/v1
+  - authentication/v1beta1
+  - authorization/v1
+  - authorization/v1beta1
+  - autoscaling/v1
+  - autoscaling/v2beta1
+  - batch/v1
+  - batch/v1beta1
+  - batch/v2alpha1
+  - certificates/v1beta1
+  - core/v1
+  - extensions/v1beta1
+  - networking/v1
+  - policy/v1beta1
+  - rbac/v1
+  - rbac/v1alpha1
+  - rbac/v1beta1
+  - scheduling/v1alpha1
+  - settings/v1alpha1
+  - storage/v1
+  - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 2de00c78cb6d6127fb51b9531c1b3def1cbcac8c
+  version: 3b05bbfa0a45413bfa184edbf9af617e277962fb
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -276,7 +322,6 @@ imports:
   - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
-  - pkg/openapi
   - pkg/runtime
   - pkg/runtime/schema
   - pkg/runtime/serializer
@@ -297,6 +342,7 @@ imports:
   - pkg/util/json
   - pkg/util/mergepatch
   - pkg/util/net
+  - pkg/util/proxy
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
@@ -312,13 +358,21 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: c809cf8581e1e44c6174bf5ab4415e6ee39965ca
+  version: c1e53d745d0fe45bf7d5d44697e6eface25fceca
   subpackages:
   - pkg/admission
   - pkg/admission/initializer
+  - pkg/admission/plugin/namespace/lifecycle
   - pkg/apis/apiserver
   - pkg/apis/apiserver/install
   - pkg/apis/apiserver/v1alpha1
+  - pkg/apis/audit
+  - pkg/apis/audit/install
+  - pkg/apis/audit/v1alpha1
+  - pkg/apis/audit/v1beta1
+  - pkg/apis/audit/validation
+  - pkg/audit
+  - pkg/audit/policy
   - pkg/authentication/authenticator
   - pkg/authentication/authenticatorfactory
   - pkg/authentication/group
@@ -326,6 +380,7 @@ imports:
   - pkg/authentication/request/bearertoken
   - pkg/authentication/request/headerrequest
   - pkg/authentication/request/union
+  - pkg/authentication/request/websocket
   - pkg/authentication/request/x509
   - pkg/authentication/serviceaccount
   - pkg/authentication/token/tokenfile
@@ -351,7 +406,6 @@ imports:
   - pkg/server/healthz
   - pkg/server/httplog
   - pkg/server/mux
-  - pkg/server/openapi
   - pkg/server/options
   - pkg/server/routes
   - pkg/server/routes/data/swagger
@@ -362,6 +416,7 @@ imports:
   - pkg/storage/etcd/metrics
   - pkg/storage/etcd/util
   - pkg/storage/etcd3
+  - pkg/storage/etcd3/preflight
   - pkg/storage/names
   - pkg/storage/storagebackend
   - pkg/storage/storagebackend/factory
@@ -370,25 +425,30 @@ imports:
   - pkg/util/flag
   - pkg/util/flushwriter
   - pkg/util/logs
-  - pkg/util/proxy
   - pkg/util/trace
-  - pkg/util/trie
   - pkg/util/webhook
   - pkg/util/wsstream
+  - plugin/pkg/audit/log
+  - plugin/pkg/audit/webhook
   - plugin/pkg/authenticator/token/webhook
   - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
-  version: 450baa5d60f8d6a251c7682cb6f86e939b750b2d
+  version: 82aa063804cf055e16e8911250f888bc216e8b61
   subpackages:
   - discovery
+  - dynamic
   - informers
+  - informers/admissionregistration
+  - informers/admissionregistration/v1alpha1
   - informers/apps
   - informers/apps/v1beta1
+  - informers/apps/v1beta2
   - informers/autoscaling
   - informers/autoscaling/v1
-  - informers/autoscaling/v2alpha1
+  - informers/autoscaling/v2beta1
   - informers/batch
   - informers/batch/v1
+  - informers/batch/v1beta1
   - informers/batch/v2alpha1
   - informers/certificates
   - informers/certificates/v1beta1
@@ -397,11 +457,16 @@ imports:
   - informers/extensions
   - informers/extensions/v1beta1
   - informers/internalinterfaces
+  - informers/networking
+  - informers/networking/v1
   - informers/policy
   - informers/policy/v1beta1
   - informers/rbac
+  - informers/rbac/v1
   - informers/rbac/v1alpha1
   - informers/rbac/v1beta1
+  - informers/scheduling
+  - informers/scheduling/v1alpha1
   - informers/settings
   - informers/settings/v1alpha1
   - informers/storage
@@ -409,75 +474,57 @@ imports:
   - informers/storage/v1beta1
   - kubernetes
   - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta2
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
   - kubernetes/typed/authorization/v1
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
-  - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2beta1
   - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1beta1
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/networking/v1
   - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/scheduling/v1alpha1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
+  - listers/admissionregistration/v1alpha1
   - listers/apps/v1beta1
+  - listers/apps/v1beta2
   - listers/autoscaling/v1
-  - listers/autoscaling/v2alpha1
+  - listers/autoscaling/v2beta1
   - listers/batch/v1
+  - listers/batch/v1beta1
   - listers/batch/v2alpha1
   - listers/certificates/v1beta1
   - listers/core/v1
   - listers/extensions/v1beta1
+  - listers/networking/v1
   - listers/policy/v1beta1
+  - listers/rbac/v1
   - listers/rbac/v1alpha1
   - listers/rbac/v1beta1
+  - listers/scheduling/v1alpha1
   - listers/settings/v1alpha1
   - listers/storage/v1
   - listers/storage/v1beta1
   - pkg/api
   - pkg/api/install
   - pkg/api/v1
-  - pkg/api/v1/ref
-  - pkg/apis/apps
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/v1
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/v1
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/autoscaling/v2alpha1
-  - pkg/apis/batch
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/v1beta1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/policy
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/rbac/v1beta1
-  - pkg/apis/settings
-  - pkg/apis/settings/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/v1
-  - pkg/apis/storage/v1beta1
-  - pkg/util
-  - pkg/util/parsers
   - pkg/version
   - rest
   - rest/watch
+  - testing
   - tools/auth
   - tools/cache
   - tools/clientcmd
@@ -485,19 +532,33 @@ imports:
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
   - tools/metrics
+  - tools/pager
+  - tools/reference
   - transport
   - util/cert
   - util/flowcontrol
   - util/homedir
   - util/integer
+- name: k8s.io/kube-openapi
+  version: 868f2f29720b192240e18284659231b440f9cda5
+  subpackages:
+  - pkg/builder
+  - pkg/common
+  - pkg/handler
+  - pkg/util
 - name: k8s.io/metrics
-  version: fd2415bb9381a6731027b48a8c6b78f28e13f876
+  version: 4c7ac522b9daf7beeb53f6766722ba78b7e5712d
   subpackages:
   - pkg/apis/custom_metrics
   - pkg/apis/custom_metrics/install
-  - pkg/apis/custom_metrics/v1alpha1
+  - pkg/apis/custom_metrics/v1beta1
 testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,9 @@
 package: github.com/kubernetes-incubator/custom-metrics-apiserver
 import:
 - package: github.com/emicklei/go-restful
+- package: github.com/emicklei/go-restful-swagger12
+- package: github.com/go-openapi/spec
+- package: github.com/golang/glog
 - package: github.com/spf13/cobra
 - package: k8s.io/apimachinery
   subpackages:
@@ -23,6 +26,7 @@ import:
 - package: k8s.io/apiserver
   subpackages:
   - pkg/endpoints
+  - pkg/endpoints/discovery
   - pkg/endpoints/handlers
   - pkg/endpoints/handlers/negotiation
   - pkg/endpoints/metrics
@@ -33,16 +37,20 @@ import:
   - pkg/util/logs
 - package: k8s.io/client-go
   subpackages:
-  - kubernetes/scheme
-  - kubernetes/typed/core/v1
+  - discovery
+  - dynamic
   - pkg/api
   - pkg/api/install
+  - pkg/api/v1
+  - pkg/version
   - rest
+  - testing
   - tools/clientcmd
 - package: k8s.io/metrics
   subpackages:
   - pkg/apis/custom_metrics
   - pkg/apis/custom_metrics/install
+testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4
   subpackages:

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -66,29 +66,22 @@ type CustomMetricsAdapterServer struct {
 }
 
 type completedConfig struct {
-	*Config
+	genericapiserver.CompletedConfig
 }
 
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() completedConfig {
-	c.GenericConfig.Complete()
-
 	c.GenericConfig.Version = &version.Info{
 		Major: "1",
 		Minor: "0",
 	}
-
-	return completedConfig{c}
-}
-
-// SkipComplete provides a way to construct a server instance without config completion.
-func (c *Config) SkipComplete() completedConfig {
-	return completedConfig{c}
+	return completedConfig{c.GenericConfig.Complete(nil)}
 }
 
 // New returns a new instance of CustomMetricsAdapterServer from the given config.
-func (c completedConfig) New(cmProvider provider.CustomMetricsProvider) (*CustomMetricsAdapterServer, error) {
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New(genericapiserver.EmptyDelegate) // completion is done in Complete, no need for a second time
+// name is used to differentiate for logging.
+func (c completedConfig) New(name string, cmProvider provider.CustomMetricsProvider) (*CustomMetricsAdapterServer, error) {
+	genericServer, err := c.CompletedConfig.New(name, genericapiserver.EmptyDelegate) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/cmapis.go
+++ b/pkg/apiserver/cmapis.go
@@ -56,7 +56,7 @@ func (s *CustomMetricsAdapterServer) InstallCustomMetricsAPI() error {
 	}
 
 	s.GenericAPIServer.DiscoveryGroupManager.AddGroup(apiGroup)
-	s.GenericAPIServer.Handler.GoRestfulContainer.Add(discovery.NewAPIGroupHandler(s.GenericAPIServer.Serializer, apiGroup).WebService())
+	s.GenericAPIServer.Handler.GoRestfulContainer.Add(discovery.NewAPIGroupHandler(s.GenericAPIServer.Serializer, apiGroup, s.GenericAPIServer.RequestContextMapper()).WebService())
 
 	return nil
 }
@@ -82,8 +82,8 @@ func (s *CustomMetricsAdapterServer) cmAPI(groupMeta *apimachinery.GroupMeta, gr
 			Context:                s.GenericAPIServer.RequestContextMapper(),
 			MinRequestTimeout:      s.GenericAPIServer.MinRequestTimeout(),
 			OptionsExternalVersion: &schema.GroupVersion{Version: "v1"},
-
-			ResourceLister: provider.NewResourceLister(s.Provider),
 		},
+
+		ResourceLister: provider.NewResourceLister(s.Provider),
 	}
 }

--- a/pkg/apiserver/installer/apiserver_test.go
+++ b/pkg/apiserver/installer/apiserver_test.go
@@ -39,7 +39,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/custom_metrics/install"
-	cmv1alpha1 "k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1"
+	cmv1beta1 "k8s.io/metrics/pkg/apis/custom_metrics/v1beta1"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	metricstorage "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/registry/custom_metrics"
@@ -127,9 +127,8 @@ func handle(prov provider.CustomMetricsProvider) http.Handler {
 
 			Context:                reqContextMapper,
 			OptionsExternalVersion: &schema.GroupVersion{Version: "v1"},
-
-			ResourceLister: provider.NewResourceLister(prov),
 		},
+		ResourceLister: provider.NewResourceLister(prov),
 	}
 
 	if err := group.InstallREST(container); err != nil {
@@ -320,7 +319,7 @@ func TestCustomMetricsAPI(t *testing.T) {
 		}
 
 		if v.ExpectedCount > 0 {
-			lst := &cmv1alpha1.MetricValueList{}
+			lst := &cmv1beta1.MetricValueList{}
 			if err := extractBody(response, lst); err != nil {
 				t.Errorf("unexpected error (%s): %v", k, err)
 				continue

--- a/pkg/apiserver/installer/installer_test.go
+++ b/pkg/apiserver/installer/installer_test.go
@@ -19,11 +19,11 @@ import (
 	"net/http"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/client-go/pkg/api"
 )
 
 type setTestSelfLinker struct {
@@ -53,11 +53,11 @@ func TestScopeNamingGenerateLink(t *testing.T) {
 		name:        "foo",
 		namespace:   "other",
 	}
+	reqInfo := &request.RequestInfo{
+		Resource: "services",
+	}
 	ctxFn := func(req *http.Request) request.Context {
-		info := &request.RequestInfo{
-			Resource: "services",
-		}
-		return request.WithRequestInfo(request.NewContext(), info)
+		return request.NewContext()
 	}
 	s := MetricsNaming{
 		handlers.ContextBasedNaming{
@@ -67,7 +67,7 @@ func TestScopeNamingGenerateLink(t *testing.T) {
 			SelfLinkPathPrefix: "/api/v1/",
 		},
 	}
-	service := &api.Service{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "other",
@@ -76,7 +76,7 @@ func TestScopeNamingGenerateLink(t *testing.T) {
 			Kind: "Service",
 		},
 	}
-	_, err := s.GenerateLink(&http.Request{}, service)
+	_, err := s.GenerateLink(reqInfo, service)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/pkg/dynamicmapper/fake_discovery.go
+++ b/pkg/dynamicmapper/fake_discovery.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	"github.com/emicklei/go-restful-swagger12"
+	"github.com/googleapis/gnostic/OpenAPIv2"
 
-	"github.com/go-openapi/spec"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/pkg/api/v1"
 	kubeversion "k8s.io/client-go/pkg/version"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/testing"
@@ -143,7 +143,9 @@ func (c *FakeDiscovery) SwaggerSchema(version schema.GroupVersion) (*swagger.Api
 	return &swagger.ApiDeclaration{}, nil
 }
 
-func (c *FakeDiscovery) OpenAPISchema() (*spec.Swagger, error) { return &spec.Swagger{}, nil }
+func (c *FakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return &openapi_v2.Document{}, nil
+}
 
 func (c *FakeDiscovery) RESTClient() restclient.Interface {
 	return nil

--- a/pkg/dynamicmapper/mapper_test.go
+++ b/pkg/dynamicmapper/mapper_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/pkg/api"
 	core "k8s.io/client-go/testing"
 )
 
@@ -33,7 +33,7 @@ const testingMapperRefreshInterval = 1 * time.Second
 
 func setupMapper(t *testing.T, stopChan <-chan struct{}) (*RegeneratingDiscoveryRESTMapper, *FakeDiscovery) {
 	fakeDiscovery := &FakeDiscovery{Fake: &core.Fake{}}
-	mapper, err := NewRESTMapper(fakeDiscovery, api.Registry.InterfacesFor, testingMapperRefreshInterval)
+	mapper, err := NewRESTMapper(fakeDiscovery, apimeta.InterfacesForUnstructured, testingMapperRefreshInterval)
 	require.NoError(t, err, "constructing the rest mapper shouldn't have produced an error")
 
 	fakeDiscovery.Resources = []*metav1.APIResourceList{

--- a/pkg/sample-cmd/provider/provider.go
+++ b/pkg/sample-cmd/provider/provider.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/pkg/api"
-	_ "k8s.io/client-go/pkg/api/install"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
@@ -77,7 +75,7 @@ func (p *incrementalTestingProvider) metricFor(value int64, groupResource schema
 	}
 
 	return &custom_metrics.MetricValue{
-		DescribedObject: api.ObjectReference{
+		DescribedObject: custom_metrics.ObjectReference{
 			APIVersion: groupResource.Group + "/" + runtime.APIVersionInternal,
 			Kind:       kind.Kind,
 			Name:       name,
@@ -97,7 +95,7 @@ func (p *incrementalTestingProvider) metricsFor(totalValue int64, groupResource 
 	res := make([]custom_metrics.MetricValue, 0)
 
 	err := apimeta.EachListItem(list, func(item runtime.Object) error {
-		objMeta := item.(metav1.ObjectMetaAccessor).GetObjectMeta()
+		objMeta := item.(metav1.Object)
 		value, err := p.metricFor(0, groupResource, objMeta.GetNamespace(), objMeta.GetName(), metricName)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit updates the deps for Kubernetes 1.8, and makes the
corresponding necessary changes to the actual code (including some
shuffling of fields and accounting for api.Registry being gone).