### PR TITLE
Fixed typo: objet -> object

### DIFF
--- a/pkg/sample-cmd/server/start.go
+++ b/pkg/sample-cmd/server/start.go
@@ -66,7 +66,7 @@ func NewCommandStartSampleAdapterServer(out, errOut io.Writer, stopCh <-chan str
 
 	flags.StringVar(&o.RemoteKubeConfigFile, "lister-kubeconfig", o.RemoteKubeConfigFile, ""+
 		"kubeconfig file pointing at the 'core' kubernetes server with enough rights to list "+
-		"any described objets")
+		"any described objects")
 	flags.DurationVar(&o.DiscoveryInterval, "discovery-interval", o.DiscoveryInterval, ""+
 		"interval at which to refresh API discovery information")
 


### PR DESCRIPTION
Fixed small typo.