### PR TITLE
Fix an yaml file error which could cause image pull failure

### DIFF
--- a/test-adapter-deploy/testing-adapter.yaml
+++ b/test-adapter-deploy/testing-adapter.yaml
@@ -51,7 +51,8 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
-        image: REGISTRY/k8s-test-metrics-adapter:latest
+        image: REGISTRY/k8s-test-metrics-adapter-amd64:latest
+        imagePullPolicy: IfNotPresent
         args:
         - /adapter
         - --secure-port=6443


### PR DESCRIPTION
This patch improve yaml file based on:

- The image name in yaml file is conflict with the one in make file. 

-    Add `imagePullPolicy: IfNotPresent` to avoid pull action when user didn't push their image to remote docker registry. It is helpful especially when it comes to fresh users who have limited knowledge about k8s/docker