### PR TITLE
Expose v1beta2 version of an API

### DIFF
--- a/pkg/apiserver/cmapis.go
+++ b/pkg/apiserver/cmapis.go
@@ -33,30 +33,34 @@ import (
 
 func (s *CustomMetricsAdapterServer) InstallCustomMetricsAPI() error {
 	groupInfo := genericapiserver.NewDefaultAPIGroupInfo(custom_metrics.GroupName, Scheme, runtime.NewParameterCodec(Scheme), Codecs)
+	container := s.GenericAPIServer.Handler.GoRestfulContainer
 
-	mainGroupVer := groupInfo.PrioritizedVersions[0]
-	preferredVersionForDiscovery := metav1.GroupVersionForDiscovery{
-		GroupVersion: mainGroupVer.String(),
-		Version:      mainGroupVer.Version,
-	}
-	groupVersion := metav1.GroupVersionForDiscovery{
-		GroupVersion: mainGroupVer.String(),
-		Version:      mainGroupVer.Version,
-	}
-	apiGroup := metav1.APIGroup{
-		Name:             mainGroupVer.Group,
-		Versions:         []metav1.GroupVersionForDiscovery{groupVersion},
-		PreferredVersion: preferredVersionForDiscovery,
-	}
+	// Register custom metrics REST handler for all supported API versions.
+	for versionIndex, mainGroupVer := range groupInfo.PrioritizedVersions {
+		preferredVersionForDiscovery := metav1.GroupVersionForDiscovery{
+			GroupVersion: mainGroupVer.String(),
+			Version:      mainGroupVer.Version,
+		}
+		groupVersion := metav1.GroupVersionForDiscovery{
+			GroupVersion: mainGroupVer.String(),
+			Version:      mainGroupVer.Version,
+		}
+		apiGroup := metav1.APIGroup{
+			Name:             mainGroupVer.Group,
+			Versions:         []metav1.GroupVersionForDiscovery{groupVersion},
+			PreferredVersion: preferredVersionForDiscovery,
+		}
 
-	cmAPI := s.cmAPI(&groupInfo, mainGroupVer)
-	if err := cmAPI.InstallREST(s.GenericAPIServer.Handler.GoRestfulContainer); err != nil {
-		return err
+		cmAPI := s.cmAPI(&groupInfo, mainGroupVer)
+		if err := cmAPI.InstallREST(container); err != nil {
+			return err
+		}
+
+		if versionIndex == 0 {
+			s.GenericAPIServer.DiscoveryGroupManager.AddGroup(apiGroup)
+			container.Add(discovery.NewAPIGroupHandler(s.GenericAPIServer.Serializer, apiGroup).WebService())
+		}
 	}
-
-	s.GenericAPIServer.DiscoveryGroupManager.AddGroup(apiGroup)
-	s.GenericAPIServer.Handler.GoRestfulContainer.Add(discovery.NewAPIGroupHandler(s.GenericAPIServer.Serializer, apiGroup).WebService())
-
 	return nil
 }
 

--- a/test-adapter-deploy/README.md
+++ b/test-adapter-deploy/README.md
@@ -1,7 +1,7 @@
 # Sample Deployment Files
 
 These files can be used to deploy the sample adapter container.  You can
-build that with `make sample-container`.  The Dockerfile describes the
+build that with `make test-adapter-container`.  The Dockerfile describes the
 container itself, while the [manifests](manifests) can be used to deploy
 that container as a provider of the custom metrics and external metrics
 APIs on the cluster.

--- a/test-adapter-deploy/testing-adapter.yaml
+++ b/test-adapter-deploy/testing-adapter.yaml
@@ -119,6 +119,20 @@ spec:
   groupPriorityMinimum: 100
   versionPriority: 100
 ---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta2.custom.metrics.k8s.io
+spec:
+  service:
+    name: custom-metrics-apiserver
+    namespace: custom-metrics
+  group: custom.metrics.k8s.io
+  version: v1beta2
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 200
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Currently only v1beta1 version of an API is exposed.
This change exposes also v1beta2 version of an API.